### PR TITLE
Brandonmp polyfilling

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,10 @@
 {
   "presets": ["es2015", "react"],
+  "plugins": ["transform-runtime"]
   "env": {
     "development": {
-      "presets": []
+      "presets": [],
+      
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babel-cli": "^6.3.17",
     "babel-core": "^6.3.21",
     "babel-loader": "^6.2.0",
+    "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "esdoc": "^0.4.7",


### PR DESCRIPTION
hey @szaranger , i'm using this module in a project built on this [chrome extension boilerplate](https://github.com/zalmoxisus/crossbuilder), and it's throwing errors related to `babel polyfills` around the `regenerator runtime`.

This PR adds the `babel-plugin-transform-runtime`, which solves the errors. 

I got the solution from [this babel issue](https://github.com/zalmoxisus/crossbuilder)

to test it, I:
- went to `myproj/node_modules/firebase-saga`
- added the plugin to `package.json`
- ran `npm run build`

And it worked fine.

Let me know if you have any questions. thanks!
brandon
