### PR TITLE
Specify redux-saga as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,6 @@
     "url": "https://github.com/szaranger/firebase-saga/issues"
   },
   "homepage": "https://github.com/szaranger/firebase-saga#readme",
-  "dependencies": {
-    "redux-saga": "^0.11.0"
-  },
   "devDependencies": {
     "babel-cli": "^6.3.17",
     "babel-core": "^6.3.21",
@@ -39,5 +36,8 @@
     "mocha": "^2.2.4",
     "rimraf": "^2.4.2",
     "webpack": "^1.13.1"
+  },
+  "peerDependencies": {
+    "redux-saga": ">=0.15.1",
   }
 }


### PR DESCRIPTION
With saga being specified as dependency the library is causing redux-saga's duplication in the user's code base if they have other version than `v0.11.x` in their projects. This library should specify that it needs `redux-saga` installed so it can properly work but it shouldnt require it on its own.

We can loosen up the restriction I've put here (`>=0.15.1`) , but it would be nice to keep it like this as additional update incentive for `redux-saga`. There were no breaking changes for quite long time in the library, so it should work just fine for everybody, except few really minor deprecation warnings which are easily fixable.